### PR TITLE
Set robots meta tag to noindex

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
     <meta name="Description" content="Information website for Stagecoach Meat Co located in Wiggins, CO" />
     <meta name="Keywords" content="Stagecoach Meat Co, Stagecoach, Meat, Wiggins, Colorado">
     <meta name="Copyright" content="2018" />
+    <meta name="robots" content="noindex" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png">
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">


### PR DESCRIPTION
Hi,

StageCoach is under new ownership and they've been trying to get in touch to mark this site not searchable. This is just a simple meta tag update to bring it to your attention.

Thanks!